### PR TITLE
Proper initialization of custom-theme-load-path.

### DIFF
--- a/org-beautify-theme.el
+++ b/org-beautify-theme.el
@@ -75,5 +75,14 @@
                           `(org-headline-done ((t (:strike-through t))))
                           `(org-done ((t (:strike-through t))))))
 
+;;;###autoload
+(when (and (boundp 'custom-theme-load-path) load-file-name)
+  (add-to-list 'custom-theme-load-path
+               (file-name-as-directory (file-name-directory load-file-name))))
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 (provide-theme 'org-beautify)
 ;;; org-beautify-theme.el ends here

--- a/org-beautify-theme.org
+++ b/org-beautify-theme.org
@@ -196,6 +196,6 @@ this is an example
 
 * Fin 🐰
 #+begin_src emacs-lisp :tangle yes
-(provide-theme 'org-beautify)
+w(provide-theme 'org-beautify)
 ;;; org-beautify-theme.el ends here
 #+end_src

--- a/org-beautify-theme.org
+++ b/org-beautify-theme.org
@@ -196,6 +196,16 @@ this is an example
 
 * Fin 🐰
 #+begin_src emacs-lisp :tangle yes
-w(provide-theme 'org-beautify)
+
+;;;###autoload
+(when (and (boundp 'custom-theme-load-path) load-file-name)
+  (add-to-list 'custom-theme-load-path
+               (file-name-as-directory (file-name-directory load-file-name))))
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
+(provide-theme 'org-beautify)
 ;;; org-beautify-theme.el ends here
 #+end_src


### PR DESCRIPTION
Add current directory to custom-theme-load-path in order to allow theme
listing with `customize-themes'.
