### PR TITLE
Fix package-lint warnings

### DIFF
--- a/org-beautify-theme.el
+++ b/org-beautify-theme.el
@@ -4,10 +4,13 @@
 ;; Author: Jonathan Arkell <jonnay@jonnay.net>
 ;; Version: 0.4
 ;; Created: 5 Oct 2012
-;; Keywords: org theme
+;; Keywords: faces org theme
+;; URL: https://github.com/jonnay/org-beautify-theme
+;; Package-Requires: ((emacs "24.1"))
 
 ;; This file is not part of GNU Emacs.
 ;; Released under the GPL v3.0
+
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation; either version 3, or (at your option)
@@ -49,8 +52,8 @@
 ;; 
 ;; * Changelog
 ;;    - v0.4 :: [2017-09-08]
-;;      - Add org-beautify-theme-use-box-hack to allow the user to 
-;;        fix ugly boxes.  
+;;      - Add org-beautify-theme-use-box-hack to allow the user to
+;;        fix ugly boxes.
 ;;    - v0.3.2 :: [2017-08-29]
 ;;      - Update License
 ;;    - v0.3.1 :: [2016-10-19]
@@ -116,9 +119,11 @@ really bad under some circumstances."
   (add-to-list 'custom-theme-load-path
                (file-name-as-directory (file-name-directory load-file-name))))
 
+(provide-theme 'org-beautify)
+(provide 'org-beautify-theme)
+
 ;; Local Variables:
 ;; no-byte-compile: t
 ;; End:
 
-(provide-theme 'org-beautify)
 ;;; org-beautify-theme.el ends here


### PR DESCRIPTION
Hi! I found this package and some [package-lint](https://github.com/purcell/package-lint) warnings.
This commit fixes below package-lint warnings

```
Package should have a Homepage or URL header. (emacs-lisp-package)
There is no (provide 'org-beautify-theme) form. (emacs-lisp-package)
You should include standard keywords: see the variable `finder-known-keywords'. (emacs-lisp-package)
White space found at end of line (emacs-lisp-checkdoc)
You should depend on (emacs "24.1") if you need `org-block'. (emacs-lisp-package)
```